### PR TITLE
get the spaces only published

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,7 +4,7 @@ class SearchController < ApplicationController
   end
 
   def search
-    @spaces = Space.prefecture_key(params[:prefecture_key]).price_min_key(params[:price_min_key]).price_max_key(params[:price_max_key]).capacity_key(params[:capacity_key]).approval_method_key(params[:approval_method_key]).purpose_key(request.url.scan(/purpose_key=([a-z_]+)/).join).page(params[:page]).per(20)
+    @spaces = Space.published.prefecture_key(params[:prefecture_key]).price_min_key(params[:price_min_key]).price_max_key(params[:price_max_key]).capacity_key(params[:capacity_key]).approval_method_key(params[:approval_method_key]).purpose_key(request.url.scan(/purpose_key=([a-z_]+)/).join).page(params[:page]).per(20)
     parameter_keys = [:prefecture_key, :price_min_key, :price_max_key, :capacity_key, :approval_method_key, :purpose_key]
     parameter_keys.each do |parameter_key|
       instance_variable_set("@exit_#{ parameter_key.to_s }", params[parameter_key]) if params[parameter_key].present?


### PR DESCRIPTION
【WHAT】
掲載審査前のスペースを検索結果に出さないように修正

【WHY】
現状ではスペース検索結果表示時に画像未登録のスペースがあるとエラーがでるため