### PR TITLE
Edit space status validation

### DIFF
--- a/app/assets/stylesheets/_edit_space.scss
+++ b/app/assets/stylesheets/_edit_space.scss
@@ -25,11 +25,18 @@
     margin-top: 40px;
   }
   &__message-wrapper {
-    background-color: $greenBackground;
-    border: 1px solid $hostGreen;
-    border-radius: 3px;
-    padding: 16px;
     margin-bottom: 20px;
+    .message__container {
+      padding: 16px;
+      background-color: $greenBackground;
+      border: 1px solid $hostGreen;
+      border-radius: 3px;
+    }
+    .message-alert {
+      background-color: $white;
+      border: 1px solid $required;
+      color: $required;
+    }
   }
   &__bottom {
     margin-top: 20px;

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -18,10 +18,11 @@ class SpacesController < ApplicationController
   end
 
   def update
-    if @space.update!(status: 1)
-      redirect_to edit_space_path(@space)
-    else
-      render :edit
+    begin
+      @space.update!(status: 1)
+    rescue ActiveRecord::RecordInvalid => e
+      logger.error e
+      redirect_to edit_space_path(@space), alert: '未入力の情報があります'
     end
   end
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -8,6 +8,8 @@ class Space < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :reservations, dependent: :destroy
 
+  validates :status, space_status_validation: true, on: :update
+
   scope :published, -> { where(published: true) }
   scope :party,  -> { joins(basic_info: [:purpose]).where('party = ?', 1) }
   scope :meeting, -> { joins(basic_info: [:purpose]).where('meeting = ?', 1) }

--- a/app/validators/space_status_validation_validator.rb
+++ b/app/validators/space_status_validation_validator.rb
@@ -1,0 +1,9 @@
+class SpaceStatusValidationValidator < ActiveModel::Validator
+  def validate(record)
+    items = [record.equipment_info, record.basic_info, record.description, record.space_image, record.plan]
+
+    unless items.all? {|item| item.present? }
+      record.errors[:status] << "未入力の情報があります"
+    end
+  end
+end

--- a/app/views/spaces/edit.html.haml
+++ b/app/views/spaces/edit.html.haml
@@ -5,8 +5,14 @@
       .flow-header__description スペースの情報を登録して、スペースを掲載することができます。スペースの編集はいつでも可能です。
     .status-page__container
       .status-page__message-wrapper
-        .message__container
-          %span.message__text スペースの作成が完了しました！
+        - if flash.any?
+          .message__container.message-alert
+            %span.message__text
+              = flash[:alert]
+        - else
+          .message__container
+            %span.message__text
+              スペースの作成が完了しました！
       .status-page__card
         .edit-publish-feature__container
           .publish-feature-card__container


### PR DESCRIPTION
# WHAT
スペースのステータス更新にモデルでのバリデーションを追加

# WHY
ボタンの表示/非表示でステータス更新の可否を実装していたが、それでは不十分なため